### PR TITLE
Unknown status renamed.

### DIFF
--- a/make_profiler/report_export.py
+++ b/make_profiler/report_export.py
@@ -25,7 +25,8 @@ def export_report(performance, docs):
             event_type = "started"
             n_in_progress += 1
         else:
-            event_type = "??unknown??"
+            # this usually occures when target is completed, but corresponding file or folder is not found. 	
+            event_type = "completed with no output"
 
         if 'finish_prev' in rec:
             last_event_time = datetime.utcfromtimestamp(


### PR DESCRIPTION
"Unknown" status occurred when target is completed, but corresponding file or folder is not found. This is correct situation for "clean" target. It may also occur for .phony targets without touch.