### PR TITLE
Wrong completed date for failed task has been fixed

### DIFF
--- a/make_profiler/report_export.py
+++ b/make_profiler/report_export.py
@@ -35,11 +35,7 @@ def export_report(performance, docs, targets):
             # this usually occurs when target is completed, but corresponding file or folder is not found.
             event_type = "completed with no output"
 
-        if 'start_current' in rec and rec["done"]:
-            last_event_time = datetime.utcfromtimestamp(
-                int(rec['finish_current'])).strftime(DATE_FORMAT)
-        elif 'start_current' in rec and not rec["done"] and not rec["running"] and not rec["failed"]:
-            # this is the case of undefined status, "completed with no output"
+        if 'start_current' in rec and (event_type == "completed" or event_type == "completed with no output"):
             last_event_time = datetime.utcfromtimestamp(
                 int(rec['finish_current'])).strftime(DATE_FORMAT)
         else:


### PR DESCRIPTION
Better to use defined event type.  Done and Failed flags can coexist in the original make_profiler record. Strange but true!