### PR TITLE
Handle missing log in export_report

### DIFF
--- a/make_profiler/report_export.py
+++ b/make_profiler/report_export.py
@@ -70,7 +70,7 @@ def export_report(performance, docs, targets):
             if last_event_time == '':
                 last_event_time = None
 
-            log_path = rec.get("log", "")
+            log_path = rec.get("log") or ""
 
             status.append(
                 {"targetName": key,

--- a/tests/test_report_export.py
+++ b/tests/test_report_export.py
@@ -1,0 +1,54 @@
+import json
+
+from make_profiler import report_export
+
+
+def _export_single_report(tmp_path, monkeypatch, record: dict[str, object]) -> dict:
+    monkeypatch.chdir(tmp_path)
+    report_export.status.clear()
+    report_export.status_list.clear()
+
+    report_export.export_report(
+        {"build": record},
+        {"build": "Build target"},
+        {"build"},
+    )
+
+    return json.loads((tmp_path / "report.json").read_text())
+
+
+def test_export_report_normalizes_missing_log_values(tmp_path, monkeypatch) -> None:
+    """Keep report consumers seeing string paths when a log key is null."""
+    report = _export_single_report(
+        tmp_path,
+        monkeypatch,
+        {
+            "running": False,
+            "failed": False,
+            "done": True,
+            "finish_prev": 1,
+            "log": None,
+        },
+    )
+
+    assert (
+        report["status"][0]["targetLog"] == ""
+    ), "targetLog should stay a string when the performance record stores log=None"
+
+
+def test_export_report_handles_missing_log_key(tmp_path, monkeypatch) -> None:
+    """Keep targetLog empty when the performance record omits the log key."""
+    report = _export_single_report(
+        tmp_path,
+        monkeypatch,
+        {
+            "running": False,
+            "failed": False,
+            "done": True,
+            "finish_prev": 1,
+        },
+    )
+
+    assert (
+        report["status"][0]["targetLog"] == ""
+    ), "targetLog should stay a string when the performance record omits log"


### PR DESCRIPTION
## Summary
- avoid `KeyError: 'log'` by defaulting to an empty string when a target has no log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5808d7dc8324a83c94b0920f17e8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Exported reports now always include the log reference as a string (empty when the original value is missing), preventing null/undefined entries in report output.

- **Tests**
  - Added an automated test to validate that exported reports normalize missing log values to an empty string.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konturio/make-profiler/pull/33)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->