### PR TITLE
Fix quoting for comments with double quotes

### DIFF
--- a/make_profiler/dot_export.py
+++ b/make_profiler/dot_export.py
@@ -114,8 +114,11 @@ def dot_node(name, performance, docstring, cp):
         node['image'] = name
         node['imagescale'] = 'true'
         node['width'] = '1'
-    node = ','.join(['%s="%s"' % (k, v) for k, v in node.items()])
-    return '"%s" [%s]' % (name, node)
+    def escape(val: str) -> str:
+        return str(val).replace("\\", "\\\\").replace('"', '\\"')
+
+    node = ','.join([f'{k}="{escape(v)}"' for k, v in node.items()])
+    return '"%s" [%s]' % (escape(name), node)
 
 
 def export_dot(f, influences, dependencies, order_only, performance, indirect_influences, docs):


### PR DESCRIPTION
## Summary
- escape double quotes when generating DOT nodes

## Testing
- `python3 -m compileall -q make_profiler`

------
https://chatgpt.com/codex/tasks/task_e_684c58168a548324bda12b57b04e02e5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of special characters in DOT graph outputs to ensure node names and attributes are displayed correctly without syntax errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->