### PR TITLE
Handle missing log in export_report

### DIFF
--- a/make_profiler/report_export.py
+++ b/make_profiler/report_export.py
@@ -70,8 +70,7 @@ def export_report(performance, docs, targets):
             if last_event_time == '':
                 last_event_time = None
 
-            if not "log" in rec:
-                rec["log"] = ""
+            log_path = rec.get("log", "")
 
             status.append(
                 {"targetName": key,
@@ -80,7 +79,7 @@ def export_report(performance, docs, targets):
                  "targetTime": event_time,
                  "targetDuration": event_duration,
                  "lastTargetCompletionTime": last_event_time,
-                 "targetLog": rec["log"]
+                 "targetLog": log_path
                  }
             )
 


### PR DESCRIPTION
## Summary
- avoid `KeyError: 'log'` by defaulting to an empty string when a target has no log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5808d7dc8324a83c94b0920f17e8