### PR TITLE
Fix clean command error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Helps managing a large data processing pipeline written in Makefile.
     xdg-open make.svg               # have a look at call graph
 
     profile_make_clean target_to_remove_with_children
+    # prints an error when the target is missing
 
     profile_make_lint               # validate Makefile to find orphan targets
     profile_make -j -k target_name  # run some target, record execution times and logs

--- a/make_profiler/cmd_clean.py
+++ b/make_profiler/cmd_clean.py
@@ -51,10 +51,19 @@ def main(argv=sys.argv[1:]):
     ast = parse(in_file)
     deps, influences, order_only, indirect_influences = get_dependencies_influences(ast)
 
+    exit_code = 0
+
     for target in args.targets:
+        if target not in influences:
+            logging.error('Target %s not found', target)
+            exit_code = 1
+            continue
+
         rm_node(target)
         clean_target(target, influences)
 
+    return exit_code
+
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,0 +1,9 @@
+import logging
+import make_profiler.cmd_clean as cmd_clean
+
+
+def test_clean_nonexistent_target(caplog):
+    with caplog.at_level(logging.ERROR):
+        ret = cmd_clean.main(['-f', 'test/example.mk', 'no_such_target'])
+    assert 'no_such_target' in caplog.text
+    assert ret == 1


### PR DESCRIPTION
## Summary
- report when cleaning a missing target
- show proper exit code and capture log in tests
- document error case in README
- test cleaning nonexistent target

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7f6e4ec88324a1ddb38b337b1dbb