### PR TITLE
Add linter warning for undefined dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Helps managing a large data processing pipeline written in Makefile.
     profile_make_clean target_to_remove_with_children
     # prints an error when the target is missing
 
-    profile_make_lint               # validate Makefile to find orphan targets
+    profile_make_lint               # validate Makefile to find orphan targets and missing rules
     profile_make -j -k target_name  # run some target, record execution times and logs
     xdg-open make.svg               # have a look at call graph with timing data
 

--- a/make_profiler/lint_makefile.py
+++ b/make_profiler/lint_makefile.py
@@ -4,6 +4,8 @@ import re
 from typing import Callable, Dict, List, Set, Tuple
 
 from make_profiler.parser import parse
+import collections
+import os
 from dataclasses import dataclass
 
 
@@ -25,21 +27,24 @@ class TargetData:
     doc: str
 
 
-def parse_targets(ast: List[Tuple[str, Dict]]) -> Tuple[List[TargetData], Set[str]]:
+def parse_targets(ast: List[Tuple[str, Dict]]) -> Tuple[List[TargetData], Set[str], Dict[str, Set[str]]]:
     target_data = []
     deps_targets = set()
+    deps_map = collections.defaultdict(set)
 
     for token_type, data in ast:
         if token_type != "target":
             continue
 
-        target_data.append(TargetData(name=data["target"], doc=data["docs"]))
+        name = data["target"]
+        target_data.append(TargetData(name=name, doc=data["docs"]))
 
         for dep_arr in data["deps"]:
             for item in dep_arr:
                 deps_targets.add(item)
-                
-    return target_data, deps_targets
+                deps_map[item].add(name)
+
+    return target_data, deps_targets, deps_map
 
 
 def validate_target_comments(targets: List[TargetData], *args) -> bool:
@@ -53,7 +58,7 @@ def validate_target_comments(targets: List[TargetData], *args) -> bool:
     return is_valid
 
 
-def validate_orphan_targets(targets: List[TargetData], deps: Set[str]) -> bool:
+def validate_orphan_targets(targets: List[TargetData], deps: Set[str], *args) -> bool:
     is_valid = True
     
     for t in targets:
@@ -61,6 +66,19 @@ def validate_orphan_targets(targets: List[TargetData], deps: Set[str]) -> bool:
             if "[FINAL]" not in t.doc:
                 print(f"{t.name}, is orphan - not marked as [FINAL] and no other target depends on it")
                 is_valid = False
+
+    return is_valid
+
+
+def validate_missing_rules(targets: List[TargetData], deps: Set[str], deps_map: Dict[str, Set[str]]) -> bool:
+    is_valid = True
+
+    target_names = {t.name for t in targets}
+    for dep in deps:
+        if dep not in target_names and not os.path.exists(dep):
+            for parent in sorted(deps_map.get(dep, [])):
+                print(f"No rule to make target '{dep}', needed by '{parent}'")
+            is_valid = False
 
     return is_valid
 
@@ -77,18 +95,22 @@ def validate_spaces(lines: List[str]) -> bool:
     return is_valid
 
 
-TARGET_VALIDATORS: Callable[[List[TargetData], Set[str]], bool] = [validate_orphan_targets, validate_target_comments]
+TARGET_VALIDATORS: Callable[[List[TargetData], Set[str], Dict[str, Set[str]]], bool] = [
+    validate_orphan_targets,
+    validate_target_comments,
+    validate_missing_rules,
+]
 TEXT_VALIDATORS: Callable[[List[str]], bool] = [validate_spaces]
 
 
-def validate(makefile_lines: List[str], targets: List[TargetData], deps: Set[str]):
+def validate(makefile_lines: List[str], targets: List[TargetData], deps: Set[str], deps_map: Dict[str, Set[str]]):
     is_valid = True
 
     for validator in TEXT_VALIDATORS:
         is_valid = validator(makefile_lines) and is_valid
 
     for validator in TARGET_VALIDATORS:
-        is_valid = validator(targets, deps) and is_valid
+        is_valid = validator(targets, deps, deps_map) and is_valid
 
     return is_valid
 
@@ -103,10 +125,10 @@ def main():
     # so it's the reason why we should open in_file twice
     with open(args.in_filename, "r") as file:
         ast = parse(file)
-    
-    targets, deps = parse_targets(ast)
 
-    if not validate(makefile_lines, targets, deps):
+    targets, deps, deps_map = parse_targets(ast)
+
+    if not validate(makefile_lines, targets, deps, deps_map):
         raise ValueError(f"Houston, we have a problem.")
 
 

--- a/tests/test_lint_makefile.py
+++ b/tests/test_lint_makefile.py
@@ -1,0 +1,12 @@
+import io
+from make_profiler import parser, lint_makefile
+
+
+def test_missing_rule(capsys):
+    mk = "all: foo\n"
+    ast = parser.parse(io.StringIO(mk))
+    targets, deps, dep_map = lint_makefile.parse_targets(ast)
+    valid = lint_makefile.validate(mk.split('\n'), targets, deps, dep_map)
+    captured = capsys.readouterr()
+    assert not valid
+    assert "No rule to make target 'foo', needed by 'all'" in captured.out


### PR DESCRIPTION
## Summary
- enhance `lint_makefile` to detect missing rules for dependencies
- document new linter behaviour
- add regression test for missing rule detection

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c81850278832494dc665b1b062e43