### PR TITLE
Fix Makefile linter false positives

### DIFF
--- a/make_profiler/lint_makefile.py
+++ b/make_profiler/lint_makefile.py
@@ -66,12 +66,23 @@ def validate_orphan_targets(targets: List[TargetData], deps: Set[str]) -> bool:
 
 
 def validate_spaces(lines: List[str]) -> bool:
+    """Validate that no line starts with spaces.
+
+    Lines that are a continuation of the previous one (the previous line
+    ends with a backslash) are ignored as Makefiles often indent continued
+    dependencies with spaces for readability.
+    """
+
     is_valid = True
 
-    regex = re.compile(r'^(?!\t[^\s]|[^\s]) | \n')
-    for i, l in enumerate(lines):
-        if re.match(regex, l):
-            print(f"Line with extra spaces ({i}): {l}")
+    for i, line in enumerate(lines):
+        if not line:  # ignore empty lines
+            continue
+        # allow leading spaces if previous line ends with a backslash
+        if i > 0 and lines[i - 1].rstrip().endswith("\\"):
+            continue
+        if line.startswith(" "):
+            print(f"Line with extra spaces ({i}): {line}")
             is_valid = False
 
     return is_valid

--- a/tests/test_lint_makefile.py
+++ b/tests/test_lint_makefile.py
@@ -1,0 +1,18 @@
+import make_profiler.lint_makefile as lint
+
+
+def test_allow_multiline_indentation():
+    lines = [
+        "target: \\",
+        "    dep1 \\",
+        "    dep2",
+    ]
+    assert lint.validate_spaces(lines)
+
+
+def test_reject_leading_spaces():
+    lines = [
+        "target:",
+        "  not_allowed",
+    ]
+    assert not lint.validate_spaces(lines)


### PR DESCRIPTION
## Summary
- allow leading spaces on lines that continue from a previous line
- add tests for linter spacing validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c82a6b7e08324a3804592fec66ef1