### PR TITLE
Fix Makefile linter for multiline spacing

### DIFF
--- a/tests/test_lint_makefile.py
+++ b/tests/test_lint_makefile.py
@@ -10,3 +10,23 @@ def test_missing_rule(capsys):
     captured = capsys.readouterr()
     assert not valid
     assert "No rule to make target 'foo', needed by 'all'" in captured.out
+
+
+def test_spaces_after_multiline_continuation(capsys):
+    mk = (
+        "all: foo bar \\\n"
+        "    baz ## [FINAL] deploy\n"
+        "foo: ## first dep\n"
+        "\t@echo foo\n"
+        "bar: ## second dep\n"
+        "\t@echo bar\n"
+        "baz: ## third dep\n"
+        "\t@echo baz\n"
+    )
+    ast = parser.parse(io.StringIO(mk))
+    targets, deps, dep_map = lint_makefile.parse_targets(ast)
+    valid = lint_makefile.validate(mk.split('\n'), targets, deps, dep_map)
+    captured = capsys.readouterr()
+    assert valid, captured.out
+
+


### PR DESCRIPTION
## Summary
- improve `validate_spaces` logic so lines starting a multiline command are allowed to be indented
- add regression test for the new rule

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c847fc7c88324a39ea51ea8b1f7d0