### PR TITLE
Fix missing cluster detection for lone root targets

### DIFF
--- a/tests/test_dot_export.py
+++ b/tests/test_dot_export.py
@@ -35,6 +35,16 @@ def test_export_escapes_special_chars():
     assert 'A \\"quote\\" doc' in data
 
 
+def test_critical_path_handles_final_targets():
+    """Ensure graph export works when a root target has no dependents."""
+    inf = {'a': set()}
+    deps = {'a': [[], []]}
+    f = io.StringIO()
+    export_dot(f, inf, deps, set(), {}, {'a': set()}, {'a': 'Doc'})
+    data = f.getvalue()
+    assert 'subgraph cluster_tools' in data
+
+
 def test_example_makefile_from_readme():
     with open('test/example.mk', encoding='utf-8') as fh:
         ast = parser.parse(fh)


### PR DESCRIPTION
## Summary
- add regression test ensuring export handles lone root targets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9a1fd1488324813c98a2ffd011e1