### PR TITLE
Add analyze command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Helps managing a large data processing pipeline written in Makefile.
 
     profile_make -a 2022-05-01      # generate overview graph with full target time only after the specified date
 
+    profile_make --analyze target_name
+                               # print timing statistics for target
+
     profile_make_init_viewer -o="~/public_html"   # Create files for web-based dashboard in the public_html folder.
 
     

--- a/make_profiler/__main__.py
+++ b/make_profiler/__main__.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from make_profiler.dot_export import export_dot, render_dot
 from make_profiler.parser import parse, get_dependencies_influences
 from make_profiler.preprocess import generate_makefile
-from make_profiler.timing import parse_timing_db
+from make_profiler.timing import parse_timing_db, analyze_target
 from make_profiler.report_export import export_report
 
 logging.basicConfig(level=logging.INFO)
@@ -53,6 +53,11 @@ def main(argv=sys.argv[1:]):
         default=None,
         help='Render report image with full target time only after the specified date in iso format (other targets will have a time of 1s)')
     parser.add_argument(
+        '--analyze',
+        dest='analyze',
+        metavar='TARGET',
+        help='Analyze timing statistics for given target')
+    parser.add_argument(
         '--disable_loop_detection',
         dest='disable_loop_detection',
         action='store_false',
@@ -68,6 +73,18 @@ def main(argv=sys.argv[1:]):
     parser.add_argument('target', nargs='?')
 
     args, unknown_args = parser.parse_known_args(argv)
+
+    if args.analyze:
+        stats = analyze_target(args.db_filename, args.analyze)
+        print('started:', stats['started'])
+        print('finished:', stats['finished'])
+        if stats['finished']:
+            print('max:', stats['max'])
+            print('min:', stats['min'])
+            print('avg:', stats['avg'])
+            print('median:', stats['median'])
+            print('last:', stats['last'])
+        return
 
     in_file = open(args.in_filename, 'r')
     if args.preprocess_only:

--- a/make_profiler/timing.py
+++ b/make_profiler/timing.py
@@ -62,3 +62,81 @@ def parse_timing_db(filename, after_date=None):
             else:
                 targets[target]['timing_sec'] = targets[target]['finish_prev'] - targets[target]['start_prev']
     return targets
+
+
+def analyze_target(filename, target_name):
+    """Return timing statistics for the given target.
+
+    Parameters
+    ----------
+    filename: str
+        Path to ``make_profile.db`` file.
+    target_name: str
+        Name of the target to analyse.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ``started`` and ``finished`` counts along with
+        ``max``, ``min``, ``avg``, ``median`` and ``last`` duration in seconds.
+    """
+
+    if not os.path.isfile(filename):
+        return {
+            'started': 0,
+            'finished': 0,
+            'max': 0,
+            'min': 0,
+            'avg': 0,
+            'median': 0,
+            'last': 0,
+        }
+
+    lines = [i.strip().split() for i in open(filename)]
+    runs = {}
+
+    for ts_str, bid, action, tgt in lines:
+        if tgt != target_name or action not in ('start', 'finish'):
+            continue
+        ts = float(ts_str)
+        runs.setdefault(bid, {}).update({action: ts})
+
+    started = 0
+    finished = 0
+    durations = []
+
+    for bid, data in runs.items():
+        if 'start' in data:
+            started += 1
+        if 'start' in data and 'finish' in data:
+            failpath = os.path.join('logs', bid, target_name, 'failed.touch')
+            if not os.path.exists(failpath):
+                finished += 1
+                durations.append((data['finish'], data['finish'] - data['start']))
+
+    durations.sort(key=lambda d: d[0])
+    times = [d[1] for d in durations]
+
+    if times:
+        max_d = max(times)
+        min_d = min(times)
+        avg_d = sum(times) / len(times)
+        n = len(times)
+        if n % 2:
+            median_d = sorted(times)[n // 2]
+        else:
+            sorted_t = sorted(times)
+            median_d = (sorted_t[n // 2 - 1] + sorted_t[n // 2]) / 2
+        last_d = times[-1]
+    else:
+        max_d = min_d = avg_d = median_d = last_d = 0
+
+    return {
+        'started': started,
+        'finished': finished,
+        'max': max_d,
+        'min': min_d,
+        'avg': avg_d,
+        'median': median_d,
+        'last': last_d,
+    }

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,0 +1,29 @@
+import os
+from make_profiler.timing import analyze_target
+
+def test_analyze_target(tmp_path):
+    db = tmp_path / "make_profile.db"
+    lines = [
+        "10 r1 start t1\n",
+        "12 r1 finish t1\n",
+        "20 r2 start t1\n",
+        "25 r2 finish t1\n",
+        "30 r3 start t1\n",
+        "34 r3 finish t1\n",
+    ]
+    db.write_text(''.join(lines))
+    (tmp_path / 'logs' / 'r2' / 't1').mkdir(parents=True)
+    (tmp_path / 'logs' / 'r2' / 't1' / 'failed.touch').write_text('')
+    (tmp_path / 'logs' / 'r1' / 't1').mkdir(parents=True)
+    (tmp_path / 'logs' / 'r3' / 't1').mkdir(parents=True)
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    stats = analyze_target(str(db), 't1')
+    os.chdir(cwd)
+    assert stats['started'] == 3
+    assert stats['finished'] == 2
+    assert stats['max'] == 4
+    assert stats['min'] == 2
+    assert stats['avg'] == 3
+    assert stats['median'] == 3
+    assert stats['last'] == 4


### PR DESCRIPTION
## Summary
- implement `analyze_target` for profiling history
- expose `--analyze` option in `profile_make` CLI
- document analyze example
- test analyzing target history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9ccd24488324abc3ddfa2d1a4e11