### PR TITLE
Implement current target highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Helps managing a large data processing pipeline written in Makefile.
 
 - Distinguish a failed target execution from forgotten touch;
 
+- Targets built in the current run are highlighted separately;
+
 - Navigate to last run's logs from each target directly from call graph;
 
 - Support for self-documented Makefiles according to

--- a/make_profiler/dot_export.py
+++ b/make_profiler/dot_export.py
@@ -100,12 +100,16 @@ def dot_node(graph, name, performance, docstring, cp, *, invisible=False):
     }
     if name in performance:
         target_performance = performance[name]
-        if target_performance['done']:
+        # Mark targets built in the current run with a dedicated color.
+        if target_performance.get('failed'):
+            node['fillcolor'] = '.05 .3 1.0'
+        elif target_performance.get('current'):
+            node['fillcolor'] = '#0969DA'
+            node['fontcolor'] = '#fff'
+        elif target_performance.get('done'):
             node['fillcolor'] = '.7 .3 1.0'
             if target_performance['isdir']:
                 node['fillcolor'] = '.2 .3 1.0'
-        if target_performance['failed']:
-            node['fillcolor'] = '.05 .3 1.0'
         timing_sec = target_performance.get('timing_sec', 0)
         timing = str(datetime.timedelta(seconds=int(timing_sec)))
         if 'log' in target_performance:

--- a/tests/test_dot_export.py
+++ b/tests/test_dot_export.py
@@ -56,3 +56,16 @@ def test_example_makefile_from_readme():
     assert 'target1 -> all' in data
     assert 'subgraph cluster_inputs' in data
     assert 'label=Input' in data
+
+
+def test_current_targets_are_highlighted():
+    inf, deps, order, _, ind, docs = build_sample()
+    perf = {
+        'a': {'done': True, 'failed': False, 'isdir': False, 'current': True},
+        'b': {'done': True, 'failed': False, 'isdir': False, 'current': False},
+    }
+    f = io.StringIO()
+    export_dot(f, inf, deps, order, perf, ind, docs)
+    data = f.getvalue()
+    assert 'fillcolor="#0969DA"' in data
+    assert 'fontcolor="#fff"' in data


### PR DESCRIPTION
## Summary
- highlight targets executed in the current run
- document highlighting in README
- test coloring of current targets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9ef0612883249c5ded8cbb83de2c