### PR TITLE
Add latest-run critical path visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Helps managing a large data processing pipeline written in Makefile.
 ![build graph example](make.png)
 
 - Critical Path is highlighted;
+- Critical Path for the latest run is shown in purple;
 
 - Inline pictures-targets into build overview;
 

--- a/make_profiler/dot_export.py
+++ b/make_profiler/dot_export.py
@@ -144,6 +144,24 @@ def export_dot(f, influences, dependencies, order_only, performance, indirect_in
 
     cp, timing_tags = critical_path(influences, dependencies, inputs, performance)
 
+    # filter graph for targets executed in the latest run
+    current_targets = {t for t, p in performance.items() if p.get('current')}
+    cur_inf = {
+        k: {d for d in v if d in current_targets}
+        for k, v in influences.items()
+        if k in current_targets
+    }
+    cur_deps = {}
+    for k, v in dependencies.items():
+        if k in current_targets:
+            cur_deps[k] = [[d for d in deps if d in current_targets] for deps in v]
+    cur_inputs = set(cur_inf.keys())
+    for v in cur_inf.values():
+        for d in v:
+            cur_inputs.discard(d)
+
+    cp_current, _ = critical_path(cur_inf, cur_deps, cur_inputs, performance)
+
     # cluster labels
     labels = {
         'cluster_inputs': 'Input',
@@ -186,6 +204,8 @@ def export_dot(f, influences, dependencies, order_only, performance, indirect_in
                 dot.edge(k, t, color="#cc0000", weight="10", penwidth="3", headclip="true")
             else:
                 dot.edge(k, t)
+            if k in cp_current and t in cp_current:
+                dot.edge(k, t, color="#6600cc", weight="10", penwidth="3", constraint="false")
 
     dot.edge('cluster_inputs_DUMMY', 'cluster_tools_DUMMY', style='invis')
     dot.edge('cluster_tools_DUMMY', 'cluster_result_DUMMY', style='invis')

--- a/tests/test_dot_export.py
+++ b/tests/test_dot_export.py
@@ -45,6 +45,33 @@ def test_critical_path_handles_final_targets():
     assert 'subgraph cluster_tools' in data
 
 
+def test_last_run_critical_path_highlighted():
+    inf = {'b': {'a'}, 'a': set()}
+    deps = {'a': [['b'], []], 'b': [[], []]}
+    perf = {
+        'a': {
+            'start_current': 0,
+            'finish_current': 1,
+            'current': True,
+            'done': True,
+            'isdir': False,
+            'failed': False,
+        },
+        'b': {
+            'start_current': 0,
+            'finish_current': 2,
+            'current': True,
+            'done': True,
+            'isdir': False,
+            'failed': False,
+        },
+    }
+    f = io.StringIO()
+    export_dot(f, inf, deps, set(), perf, {'a': set(), 'b': set()}, {'a': 'A', 'b': 'B'})
+    data = f.getvalue()
+    assert 'color="#6600cc"' in data
+
+
 def test_example_makefile_from_readme():
     with open('test/example.mk', encoding='utf-8') as fh:
         ast = parser.parse(fh)


### PR DESCRIPTION
## Summary
- highlight critical path for the latest run in purple
- document new feature in README
- test highlighting of last run path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9f36a68c8324a7976cd840e45241