### PR TITLE
Add grouped target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Helps managing a large data processing pipeline written in Makefile.
 
 - Navigate to last run's logs from each target directly from call graph;
 
+- Grouped targets using `&:` are displayed as one node;
 - Support for self-documented Makefiles according to
   http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 

--- a/make_profiler/__main__.py
+++ b/make_profiler/__main__.py
@@ -88,12 +88,13 @@ def main(argv=sys.argv[1:]):
         logger.info(' '.join(cmd))
         subprocess.call(cmd)
 
-    docs = dict([
-        (i[1]['target'], i[1]['docs'])
-        for i in ast if i[0] == 'target'
-    ])
+    docs = {}
+    for item_type, data in ast:
+        if item_type == 'target':
+            for t in data.get('targets', [data['target']]):
+                docs[t] = data['docs']
     performance = parse_timing_db(args.db_filename, args.after_date)
-    deps, influences, order_only, indirect_influences = get_dependencies_influences(ast)
+    deps, influences, order_only, indirect_influences, groups = get_dependencies_influences(ast)
 
     dot_file = io.StringIO()
 
@@ -104,7 +105,8 @@ def main(argv=sys.argv[1:]):
         order_only,
         performance,
         indirect_influences,
-        docs
+        docs,
+        groups,
     )
     dot_file.seek(0)
 

--- a/make_profiler/cmd_clean.py
+++ b/make_profiler/cmd_clean.py
@@ -49,7 +49,7 @@ def main(argv=sys.argv[1:]):
     in_file = open(args.in_filename, 'r') if args.in_filename else sys.stdin
 
     ast = parse(in_file)
-    deps, influences, order_only, indirect_influences = get_dependencies_influences(ast)
+    deps, influences, order_only, indirect_influences, _ = get_dependencies_influences(ast)
 
     exit_code = 0
 

--- a/make_profiler/preprocess.py
+++ b/make_profiler/preprocess.py
@@ -78,7 +78,10 @@ def generate_makefile(ast, fd, db_filename):
         if item_type == Tokens.expression:
             fd.write('{}\n'.format(item))
         elif item_type == Tokens.target:
-            fd.write('{}:'.format(item['target']))
+            targets = item.get('targets', [item['target']])
+            separator = '&:' if item.get('separator') == '&:' else ':'
+            join = ' '.join(targets)
+            fd.write(f"{join} {separator}" if separator == '&:' else f"{join}:")
             deps, order_deps = item['deps']
             if deps:
                 fd.write(' {}'.format(' '.join(deps)))


### PR DESCRIPTION
## Summary
- support grouped targets with `&:` in parser and preprocessing
- warn about `:` with multiple targets in Makefile lint
- handle docs for each target in CLI
- render grouped targets as a single node in graphs
- update README
- tests for grouped target rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ca084760c8324addd9ec39870cc20