### PR TITLE
Improve space linting messages

### DIFF
--- a/make_profiler/lint_makefile.py
+++ b/make_profiler/lint_makefile.py
@@ -120,15 +120,22 @@ def validate_spaces(lines: List[str], *, errors: List[str] | None = None) -> boo
         if prev_line.rstrip().endswith("\\"):
             prev_line = line
             if line.rstrip() != line:
-                msg = f"Line with extra spaces ({i}): {line}"
+                msg = f"Trailing spaces ({i}): {line}"
                 print(msg)
                 if errors is not None:
                     errors.append(msg)
                 is_valid = False
             continue
 
-        if line.rstrip() != line or (line.startswith(" ") and not line.startswith("\t")):
-            msg = f"Line with extra spaces ({i}): {line}"
+        if line.rstrip() != line:
+            msg = f"Trailing spaces ({i}): {line}"
+            print(msg)
+            if errors is not None:
+                errors.append(msg)
+            is_valid = False
+
+        if line.startswith(" ") and not line.startswith("\t"):
+            msg = f"Space instead of tab ({i}): {line}"
             print(msg)
             if errors is not None:
                 errors.append(msg)

--- a/tests/test_lint_makefile.py
+++ b/tests/test_lint_makefile.py
@@ -31,6 +31,34 @@ def test_spaces_after_multiline_continuation(capsys):
     assert valid, captured.out
 
 
+def test_trailing_spaces(capsys):
+    mk = (
+        "all: foo ## [FINAL] doc  \n"
+        "\t@echo foo\n"
+        "foo: ## doc\n"
+        "\t@echo bar\n"
+    )
+    ast = parser.parse(io.StringIO(mk))
+    targets, deps, dep_map = lint_makefile.parse_targets(ast)
+    valid = lint_makefile.validate(mk.split('\n'), targets, deps, dep_map)
+    captured = capsys.readouterr()
+    assert not valid
+    assert "Trailing spaces" in captured.out
+
+
+def test_space_instead_of_tab(capsys):
+    mk = (
+        "all: ## [FINAL] doc\n"
+        "  @echo foo\n"
+    )
+    ast = parser.parse(io.StringIO(mk))
+    targets, deps, dep_map = lint_makefile.parse_targets(ast)
+    valid = lint_makefile.validate(mk.split('\n'), targets, deps, dep_map)
+    captured = capsys.readouterr()
+    assert not valid
+    assert "Space instead of tab" in captured.out
+
+
 def test_main_reports_summary(tmp_path, monkeypatch, capsys):
     mk = "all: foo\n"
     mfile = tmp_path / "Makefile"


### PR DESCRIPTION
## Summary
- give `lint_makefile` specific messages for trailing spaces vs. using spaces instead of tabs
- test the new error messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df3b87db88324b7e2e992365c71a8