### PR TITLE
Add grouped targets support

### DIFF
--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -26,3 +26,17 @@ The `critical path` is the longest sequence of dependent targets determined by `
 ## Tools and results
 Targets that nobody depends on are classified as results. Targets that have no dependencies and no dependents are classified as tools (for example, `clean`). These groupings control the visual clusters in the SVG output.
 
+## Grouped targets
+Using `&:` in a rule declares that several targets are produced by the same
+command block. For example:
+
+```make
+foo bar &: deps
+@echo building both
+```
+
+The profiler merges `foo` and `bar` into one node so the recipe appears only
+once in the call graph. When multiple targets are listed with a plain `:`, Make
+may run the recipe more than once in parallel; the linter reports this pattern
+and suggests using `&:` instead.
+

--- a/make_profiler/__main__.py
+++ b/make_profiler/__main__.py
@@ -88,10 +88,12 @@ def main(argv=sys.argv[1:]):
         logger.info(' '.join(cmd))
         subprocess.call(cmd)
 
-    docs = dict([
-        (i[1]['target'], i[1]['docs'])
-        for i in ast if i[0] == 'target'
-    ])
+    docs = {}
+    for ttype, data in ast:
+        if ttype != 'target':
+            continue
+        for name in data.get('all_targets', [data['target']]):
+            docs[name] = data['docs']
     performance = parse_timing_db(args.db_filename, args.after_date)
     deps, influences, order_only, indirect_influences = get_dependencies_influences(ast)
 

--- a/make_profiler/lint_makefile.py
+++ b/make_profiler/lint_makefile.py
@@ -37,6 +37,7 @@ class TargetData:
     doc: str
     line_number: int | None = None
     line_text: str | None = None
+    grouped: bool = False
 
 
 def _create_error(
@@ -59,7 +60,7 @@ def _compute_target_lines(lines: list[str]) -> dict[str, tuple[int, str]]:
     mapping: dict[str, tuple[int, str]] = {}
     i = 0
     n = len(lines)
-    target_re = re.compile(r"(?P<target>[^:]+):")
+    target_re = re.compile(r"(?P<target>.+?)(?:&:|:)")
 
     while i < n:
         line = lines[i]
@@ -108,21 +109,24 @@ def parse_targets(
         if token_type != "target":
             continue
 
-        name = data["target"]
-        line_number, line_text = line_map.get(name, (None, None))
-        target_data.append(
-            TargetData(
-                name=name,
-                doc=data["docs"],
-                line_number=line_number,
-                line_text=line_text,
+        names = data.get("all_targets", [data["target"]])
+        for name in names:
+            line_number, line_text = line_map.get(name, (None, None))
+            target_data.append(
+                TargetData(
+                    name=name,
+                    doc=data["docs"],
+                    line_number=line_number,
+                    line_text=line_text,
+                    grouped=data.get("grouped", False),
+                )
             )
-        )
 
         for dep_arr in data["deps"]:
             for item in dep_arr:
                 deps_targets.add(item)
-                deps_map[item].add(name)
+                for name in names:
+                    deps_map[item].add(name)
 
     return target_data, deps_targets, deps_map
 
@@ -261,10 +265,47 @@ def validate_spaces(lines: list[str], *, errors: list[LintError] | None = None) 
     return is_valid
 
 
+def validate_multiple_targets_colon(
+    targets: list[TargetData],
+    _deps: set[str],
+    _dep_map: dict[str, set[str]],
+    *,
+    errors: list[LintError] | None = None,
+) -> bool:
+    """Warn when multiple targets share a rule without '&:' grouping."""
+    is_valid = True
+
+    for t in targets:
+        if t.grouped or t.line_text is None:
+            continue
+        m = re.match(r"(?P<target>.+?)(?:&:|:)", t.line_text)
+        if m:
+            names = m.group("target").split()
+            if len(names) > 1:
+                msg = (
+                    f"Multiple targets defined with ':' may run several times in parallel: "
+                    f"{m.group('target')}. Use '&:' to group them"
+                )
+                print(msg, file=sys.stderr)
+                if errors is not None:
+                    errors.append(
+                        _create_error(
+                            "multiple targets with colon",
+                            msg,
+                            line_number=t.line_number,
+                            line_text=t.line_text,
+                        ),
+                    )
+                is_valid = False
+
+    return is_valid
+
+
 TARGET_VALIDATORS: list[Callable[..., bool]] = [
     validate_orphan_targets,
     validate_target_comments,
     validate_missing_rules,
+    validate_multiple_targets_colon,
 ]
 # The list holds validators with varying signatures, so use a generic Callable.
 TEXT_VALIDATORS: list[Callable[..., bool]] = [validate_spaces]

--- a/make_profiler/parser.py
+++ b/make_profiler/parser.py
@@ -127,24 +127,45 @@ def parse(fd: TextIO, is_check_loop: bool = True, loop_check_depth: int = 20) ->
     it = peekable(tokenizer(insert_included_files(fd, is_check_loop, loop_check_depth)))
 
     def parse_target(token: Tuple[Tokens, str]):
+        """Parse a Makefile rule and store it in the AST.
+
+        Supports both traditional ``target:`` syntax and ``&:`` grouped
+        targets introduced in GNU make 4.3. When ``&:`` is used all targets
+        in the list are produced by a single recipe execution.
+        """
         line = token[1]
-        target, deps, order_deps, docstring = re.match(
-            r'(.+?): \s? ([^|#]+)? \s? [|]? \s? ([^##]+)? \s?  \s? ([#][#].+)?',
-            line,
-            re.X
-        ).groups()
+
+        sep = '&:' if '&:' in line else ':'
+        target_part, rest = line.split(sep, 1)
+        targets = target_part.strip().split()
+
+        docs = ''
+        if '##' in rest:
+            rest, docs = rest.split('##', 1)
+            docs = docs.strip()
+
+        rest = rest.strip()
+        if '|' in rest:
+            deps_part, order_part = rest.split('|', 1)
+            order_deps = sorted(order_part.strip().split()) if order_part.strip() else []
+        else:
+            deps_part = rest
+            order_deps = []
+        deps = sorted(deps_part.strip().split()) if deps_part.strip() else []
+
         body = parse_body()
-        ast.append((
-            token[0],
-            {
-                'target': target.strip(),
-                'deps': [
-                    sorted(deps.strip().split()) if deps else [],
-                    sorted(order_deps.strip().split()) if order_deps else []
-                ],
-                'docs': docstring.strip().strip('#').strip() if docstring else '',
-                'body': body
-            })
+        ast.append(
+            (
+                token[0],
+                {
+                    'target': targets[0],
+                    'all_targets': targets,
+                    'grouped': sep == '&:',
+                    'deps': [deps, order_deps],
+                    'docs': docs,
+                    'body': body,
+                },
+            )
         )
 
     def next_belongs_to_target() -> bool:
@@ -176,11 +197,25 @@ def get_dependencies_influences(ast: List[Tuple[Tokens, Dict[str, Any]]]):
     order_only = set()
     indirect_influences = collections.defaultdict(set)
 
+    alias_map = {}
     for item_t, item in ast:
         if item_t != Tokens.target:
             continue
-        target = item['target']
+        targets = item.get('all_targets', [item['target']])
+        canonical = targets[0]
+        for alias in targets[1:]:
+            alias_map[alias] = canonical
+
+    def alias(name: str) -> str:
+        return alias_map.get(name, name)
+
+    for item_t, item in ast:
+        if item_t != Tokens.target:
+            continue
+        target = alias(item['target'])
         deps, order_deps = item['deps']
+        deps = [alias(d) for d in deps]
+        order_deps = [alias(d) for d in order_deps]
 
         if target in ('.PHONY',):
             continue

--- a/make_profiler/preprocess.py
+++ b/make_profiler/preprocess.py
@@ -78,7 +78,9 @@ def generate_makefile(ast, fd, db_filename):
         if item_type == Tokens.expression:
             fd.write('{}\n'.format(item))
         elif item_type == Tokens.target:
-            fd.write('{}:'.format(item['target']))
+            targets = item.get('all_targets', [item['target']])
+            sep = '&:' if item.get('grouped') else ':'
+            fd.write('{}{}'.format(' '.join(targets), sep))
             deps, order_deps = item['deps']
             if deps:
                 fd.write(' {}'.format(' '.join(deps)))

--- a/tests/test_dot_export.py
+++ b/tests/test_dot_export.py
@@ -81,3 +81,23 @@ def test_current_run_critical_path_colored():
     export_dot(f, inf, deps, order, perf, ind, docs)
     data = f.getvalue()
     assert 'color="#800080"' in data
+
+
+def test_grouped_targets_render_once():
+    mk = (
+        "a b &:\n"
+        "\t@true\n"
+        "c: a\n"
+        "\t@true\n"
+        "d: b\n"
+        "\t@true\n"
+    )
+    ast = parser.parse(io.StringIO(mk))
+    deps, inf, order, indirect = parser.get_dependencies_influences(ast)
+    docs = {t[1]['target']: t[1]['docs'] for t in ast if t[0] == parser.Tokens.target}
+    f = io.StringIO()
+    export_dot(f, inf, deps, order, {}, indirect, docs)
+    data = f.getvalue()
+    assert 'a -> c' in data
+    assert 'a -> d' in data
+    assert 'b ->' not in data  # b is merged with a

--- a/tests/test_lint_makefile.py
+++ b/tests/test_lint_makefile.py
@@ -1,5 +1,4 @@
 import io
-import pytest
 from make_profiler import parser, lint_makefile
 
 
@@ -134,5 +133,26 @@ def test_summary_counts_similar_errors() -> None:
     summary = lint_makefile.summarize_errors(errors)
     assert "space instead of tab: 3" in summary
     assert "missing rule: 1" in summary
+
+
+def test_multiple_targets_with_colon_warns() -> None:
+    mk = (
+        "foo bar: dep\n"
+        "\t@echo hi\n"
+    )
+    valid, errors = run_validation(mk)
+    assert not valid
+    assert any(e.error_type == "multiple targets with colon" for e in errors)
+
+
+def test_multiple_targets_grouped_is_ok() -> None:
+    mk = (
+        "foo bar &: dep ## [FINAL] doc\n"
+        "\t@echo hi\n"
+        "dep: ## used\n"
+        "\t@echo dep\n"
+    )
+    valid, errors = run_validation(mk)
+    assert valid, errors
 
 


### PR DESCRIPTION
## Summary
- support '&:' grouped targets in parser and preprocess
- warn about multi-target rules without grouping in linter
- show grouped targets as one node in Graphviz
- document grouped targets in terminology
- test linter and graph output with grouped targets
- improve comments on parser and docs

## Testing
- `ruff make_profiler tests docs`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867e93e0e4083249ff1f0b5f4d3c001