### PR TITLE
Handle missing log in export_report

### DIFF
--- a/make_profiler/report_export.py
+++ b/make_profiler/report_export.py
@@ -70,7 +70,7 @@ def export_report(performance, docs, targets):
             if last_event_time == '':
                 last_event_time = None
 
-            log_path = rec.get("log", "")
+            log_path = rec.get("log") or ""
 
             status.append(
                 {"targetName": key,

--- a/tests/test_report_export.py
+++ b/tests/test_report_export.py
@@ -1,0 +1,54 @@
+import json
+
+from make_profiler import report_export
+
+
+def _export_single_report(tmp_path, monkeypatch, record: dict[str, object]) -> dict:
+    monkeypatch.chdir(tmp_path)
+    report_export.status.clear()
+    report_export.status_list.clear()
+
+    report_export.export_report(
+        {"build": record},
+        {"build": "Build target"},
+        {"build"},
+    )
+
+    return json.loads((tmp_path / "report.json").read_text())
+
+
+def test_export_report_normalizes_missing_log_values(tmp_path, monkeypatch) -> None:
+    """Keep report consumers seeing string paths when a log key is null."""
+    report = _export_single_report(
+        tmp_path,
+        monkeypatch,
+        {
+            "running": False,
+            "failed": False,
+            "done": True,
+            "finish_prev": 1,
+            "log": None,
+        },
+    )
+
+    assert (
+        report["status"][0]["targetLog"] == ""
+    ), "targetLog should stay a string when the performance record stores log=None"
+
+
+def test_export_report_handles_missing_log_key(tmp_path, monkeypatch) -> None:
+    """Keep targetLog empty when the performance record omits the log key."""
+    report = _export_single_report(
+        tmp_path,
+        monkeypatch,
+        {
+            "running": False,
+            "failed": False,
+            "done": True,
+            "finish_prev": 1,
+        },
+    )
+
+    assert (
+        report["status"][0]["targetLog"] == ""
+    ), "targetLog should stay a string when the performance record omits log"


### PR DESCRIPTION
## Summary
- keep exported `targetLog` as an empty string when the performance record has `log: None`
- keep the same empty-string behavior when the `log` key is absent
- move the branch source from `konturio` to `maumaps`

## Testing
- `git diff --check origin/master...maumaps/codex/fix-keyerror--log--on-geocint`
- previous exact-head validation on `81bce12`: `pytest -q`, `ruff check make_profiler tests/test_report_export.py`, `pylint --disable=all --enable=E make_profiler`, and GitHub CI/Lint passed on konturio/make-profiler#33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed report export to properly normalize missing or empty log values, ensuring consistent output formatting.

* **Tests**
  * Added test coverage to validate the correct handling of missing log values in exported reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konturio/make-profiler/pull/55)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->